### PR TITLE
Fix: do not check for the "Drops" tag anymore

### DIFF
--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/api/gql/gql/data/types/Tag.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/api/gql/gql/data/types/Tag.java
@@ -18,8 +18,6 @@ import org.jetbrains.annotations.NotNull;
 @ToString
 @Builder
 public class Tag extends GQLType{
-	public static final String DROPS_TAG_ID = "c2542d6d-cd10-4532-919b-3d19f30a768b";
-	
 	@JsonProperty("id")
 	@NotNull
 	private String id;

--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/priority/DropsPriority.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/priority/DropsPriority.java
@@ -6,7 +6,6 @@ import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.dropshighlightservi
 import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.types.Channel;
 import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.types.DropBenefitEdge;
 import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.types.DropCampaign;
-import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.types.Tag;
 import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.types.TimeBasedDrop;
 import fr.rakambda.channelpointsminer.miner.factory.TimeFactory;
 import fr.rakambda.channelpointsminer.miner.miner.IMiner;
@@ -19,7 +18,6 @@ import lombok.experimental.SuperBuilder;
 import lombok.extern.log4j.Log4j2;
 import org.jetbrains.annotations.NotNull;
 import java.util.Collection;
-import java.util.Objects;
 import java.util.Optional;
 
 @JsonTypeName("drops")
@@ -35,8 +33,7 @@ public class DropsPriority extends IStreamerPriority{
 	public int getScore(@NotNull IMiner miner, @NotNull Streamer streamer){
 		if(streamer.isParticipateCampaigns()
 				&& streamer.isStreamingGame()
-				&& hasCampaigns(streamer)
-				&& hasDropsTag(streamer)){
+				&& hasCampaigns(streamer)){
 			return getScore();
 		}
 		
@@ -50,11 +47,6 @@ public class DropsPriority extends IStreamerPriority{
 				.stream()
 				.flatMap(Collection::stream)
 				.anyMatch(this::isValidCampaign);
-	}
-	
-	private boolean hasDropsTag(@NotNull Streamer streamer){
-		return streamer.getTags().stream()
-				.anyMatch(tag -> Objects.equals(tag.getId(), Tag.DROPS_TAG_ID));
 	}
 	
 	private boolean isValidCampaign(@NotNull DropCampaign dropCampaign){

--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/streamer/Streamer.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/streamer/Streamer.java
@@ -10,7 +10,6 @@ import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.types.CommunityPoin
 import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.types.CommunityPointsProperties;
 import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.types.Game;
 import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.types.Stream;
-import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.types.Tag;
 import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.types.User;
 import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.videoplayerstreaminfooverlaychannel.VideoPlayerStreamInfoOverlayChannelData;
 import fr.rakambda.channelpointsminer.miner.factory.TimeFactory;
@@ -190,15 +189,6 @@ public class Streamer{
 		return Optional.ofNullable(videoPlayerStreamInfoOverlayChannel)
 				.map(VideoPlayerStreamInfoOverlayChannelData::getUser)
 				.map(User::getProfileImageUrl);
-	}
-	
-	@NotNull
-	public List<Tag> getTags(){
-		return Optional.ofNullable(videoPlayerStreamInfoOverlayChannel)
-				.map(VideoPlayerStreamInfoOverlayChannelData::getUser)
-				.map(User::getStream)
-				.map(Stream::getTags)
-				.orElse(List.of());
 	}
 	
 	public boolean isParticipateCampaigns(){

--- a/miner/src/test/java/fr/rakambda/channelpointsminer/miner/priority/DropsPriorityTest.java
+++ b/miner/src/test/java/fr/rakambda/channelpointsminer/miner/priority/DropsPriorityTest.java
@@ -54,7 +54,6 @@ class DropsPriorityTest{
 	void setUp(){
 		lenient().when(streamer.isParticipateCampaigns()).thenReturn(true);
 		lenient().when(streamer.isStreamingGame()).thenReturn(true);
-		lenient().when(streamer.getTags()).thenReturn(List.of(tag));
 		
 		lenient().when(tag.getId()).thenReturn(DROPS_TAG_ID);
 		
@@ -91,17 +90,6 @@ class DropsPriorityTest{
 			timeFactory.when(TimeFactory::nowZoned).thenReturn(NOW);
 			
 			when(streamer.isStreamingGame()).thenReturn(false);
-			
-			assertThat(tested.getScore(miner, streamer)).isEqualTo(0);
-		}
-	}
-	
-	@Test
-	void withoutDropsTag(){
-		try(var timeFactory = mockStatic(TimeFactory.class)){
-			timeFactory.when(TimeFactory::nowZoned).thenReturn(NOW);
-			
-			when(streamer.getTags()).thenReturn(List.of());
 			
 			assertThat(tested.getScore(miner, streamer)).isEqualTo(0);
 		}

--- a/miner/src/test/java/fr/rakambda/channelpointsminer/miner/streamer/StreamerTest.java
+++ b/miner/src/test/java/fr/rakambda/channelpointsminer/miner/streamer/StreamerTest.java
@@ -510,30 +510,6 @@ class StreamerTest{
 	}
 	
 	@Test
-	void getTags(){
-		when(videoPlayerStreamInfoOverlayChannelData.getUser()).thenReturn(user);
-		when(user.getStream()).thenReturn(stream);
-		when(stream.getTags()).thenReturn(List.of(tag));
-		
-		assertThat(tested.getTags()).containsExactlyInAnyOrder(tag);
-	}
-	
-	@Test
-	void getTagsNoStream(){
-		when(videoPlayerStreamInfoOverlayChannelData.getUser()).thenReturn(user);
-		when(user.getStream()).thenReturn(null);
-		
-		assertThat(tested.getTags()).isEmpty();
-	}
-	
-	@Test
-	void getTagsNoChannelData(){
-		tested.setVideoPlayerStreamInfoOverlayChannel(null);
-		
-		assertThat(tested.getTags()).isEmpty();
-	}
-	
-	@Test
 	void getIndex(){
 		var index = 6;
 		when(settings.getIndex()).thenReturn(index);


### PR DESCRIPTION
It isn't present on all channels that can have drops. Checking DropsHighlights should be enough.

## Pull Request Etiquette

### Checklist

- [x] Tests have been added in relevant areas
- [ ] Corresponding changes made to the documentation (README.adoc) <!-- (if irrelevant check the box too) -->

### Type of change
Bug fix

## Description
CPM was expecting a "Drops" tag on the stream but it seems it isn't always present anymore.
