### PR TITLE
Add option to ignore subscriber drops & fix checking drop count

### DIFF
--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/api/gql/gql/GQLApi.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/api/gql/gql/GQLApi.java
@@ -201,6 +201,11 @@ public class GQLApi{
         String cursor = null;
         do{
             var response = channelFollows(100, ORDER_DESC, cursor);
+			if(response.isEmpty()){
+				log.error("Failed to load follows, response is empty");
+				break;
+			}
+			
             var followConnection = response.map(GQLResponse::getData).map(ChannelFollowsData::getUser).map(User::getFollows);
             
             followConnection.stream()

--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/api/gql/gql/data/dropshighlightserviceavailabledrops/DropsHighlightServiceAvailableDropsOperation.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/api/gql/gql/data/dropshighlightserviceavailabledrops/DropsHighlightServiceAvailableDropsOperation.java
@@ -15,7 +15,7 @@ import org.jetbrains.annotations.NotNull;
 public class DropsHighlightServiceAvailableDropsOperation extends IGQLOperation<DropsHighlightServiceAvailableDropsData>{
     public DropsHighlightServiceAvailableDropsOperation(@NotNull String channelId){
         super("DropsHighlightService_AvailableDrops");
-	    addPersistedQueryExtension(new PersistedQueryExtension(1, "9a62a09bce5b53e26e64a671e530bc599cb6aab1e5ba3cbd5d85966d3940716f"));
+	    addPersistedQueryExtension(new PersistedQueryExtension(1, "962510a535f25f33bbf85d7767982e3bb6d1b00f84dd3c7a06d8572323dfd010"));
         addVariable("channelID", channelId);
     }
     

--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/api/gql/gql/data/types/DropCampaign.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/api/gql/gql/data/types/DropCampaign.java
@@ -74,4 +74,7 @@ public class DropCampaign extends GQLType{
 	@JsonProperty("allow")
 	@Nullable
 	private DropCampaignACL allow;
+	@JsonProperty("summary")
+	@Nullable
+	private DropCampaignSummary summary;
 }

--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/api/gql/gql/data/types/DropCampaignSummary.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/api/gql/gql/data/types/DropCampaignSummary.java
@@ -8,21 +8,15 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import org.jetbrains.annotations.Nullable;
 
-@JsonTypeName("DropBenefitEdge")
+@JsonTypeName("DropCampaignSummary")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 @EqualsAndHashCode(callSuper = true)
 @ToString
-public class DropBenefitEdge extends GQLType{
-	@JsonProperty("benefit")
-	private DropBenefit benefit;
-	@JsonProperty("entitlementLimit")
-	private int entitlementLimit;
-	@JsonProperty("claimCount")
-	@Nullable
-	private Integer claimCount;
+public class DropCampaignSummary extends GQLType{
+	@JsonProperty("includesSubRequirement")
+	private boolean includesSubRequirement;
 }

--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/api/gql/gql/data/types/GQLType.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/api/gql/gql/data/types/GQLType.java
@@ -61,6 +61,7 @@ import lombok.Getter;
         @JsonSubTypes.Type(value = CommunityPointsEmoteModifier.class, name = "CommunityPointsEmoteModifier"),
         @JsonSubTypes.Type(value = StreamPlaybackAccessToken.class, name = "PlaybackAccessToken"),
         @JsonSubTypes.Type(value = RewardCampaign.class, name = "RewardCampaign"),
+        @JsonSubTypes.Type(value = DropCampaignSummary.class, name = "DropCampaignSummary"),
 })
 @EqualsAndHashCode
 public abstract class GQLType{

--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/streamer/Streamer.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/streamer/Streamer.java
@@ -101,6 +101,10 @@ public class Streamer{
 		return settings.isFollowRaid();
 	}
 	
+	public boolean isExcludeSubscriberDrops(){
+		return settings.isExcludeSubscriberDrops();
+	}
+	
 	public boolean needUpdate(){
 		return TimeFactory.now().isAfter(lastUpdated.plus(5, MINUTES));
 	}

--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/streamer/StreamerSettings.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/streamer/StreamerSettings.java
@@ -51,6 +51,10 @@ public class StreamerSettings{
 	@JsonPropertyDescription("Join chat. Default: false")
 	@Builder.Default
 	private boolean joinIrc = false;
+	@JsonProperty("excludeSubscriberDrops")
+	@JsonPropertyDescription("Exclude progressing drops that require subscriptions. Default: true")
+	@Builder.Default
+	private boolean excludeSubscriberDrops = true;
 	@JsonProperty("index")
 	@JsonPropertyDescription("The streamer index. This value is used when streamers have the same score from the defined priorities, the one with the lowest index will be picked first. Default: 2147483647")
 	@Builder.Default
@@ -74,6 +78,7 @@ public class StreamerSettings{
 		followRaid = origin.followRaid;
 		participateCampaigns = origin.participateCampaigns;
 		joinIrc = origin.joinIrc;
+		excludeSubscriberDrops = origin.excludeSubscriberDrops;
 		index = origin.index;
 		predictions = new PredictionSettings(origin.predictions);
 		priorities.addAll(origin.priorities);

--- a/miner/src/test/java/fr/rakambda/channelpointsminer/miner/api/gql/gql/AbstractGQLTest.java
+++ b/miner/src/test/java/fr/rakambda/channelpointsminer/miner/api/gql/gql/AbstractGQLTest.java
@@ -69,7 +69,7 @@ public abstract class AbstractGQLTest{
 		expectGqlRequest(requestBody, 200, responseBody);
 	}
 	
-	private void expectGqlRequest(String requestBody, int responseStatus, String responseBody){
+	protected void expectGqlRequest(String requestBody, int responseStatus, String responseBody){
 		unirest.expect(POST, "https://gql.twitch.tv/gql")
 				.header("Authorization", "OAuth " + ACCESS_TOKEN)
 				.header("Client-Integrity", currentIntegrityToken)

--- a/miner/src/test/java/fr/rakambda/channelpointsminer/miner/api/gql/gql/GQLApiDropsHighlightServiceAvailableDropsTest.java
+++ b/miner/src/test/java/fr/rakambda/channelpointsminer/miner/api/gql/gql/GQLApiDropsHighlightServiceAvailableDropsTest.java
@@ -6,6 +6,7 @@ import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.types.Channel;
 import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.types.DropBenefit;
 import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.types.DropBenefitEdge;
 import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.types.DropCampaign;
+import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.types.DropCampaignSummary;
 import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.types.Game;
 import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.types.TimeBasedDrop;
 import fr.rakambda.channelpointsminer.miner.tests.UnirestMock;
@@ -64,6 +65,9 @@ class GQLApiDropsHighlightServiceAvailableDropsTest extends AbstractGQLTest{
                                                         .build()))
                                                 .requiredMinutesWatched(240)
                                                 .build()))
+				                                .summary(DropCampaignSummary.builder()
+						                                .includesSubRequirement(true)
+						                                .build())
                                         .build()))
                                 .build())
                         .build())
@@ -100,6 +104,6 @@ class GQLApiDropsHighlightServiceAvailableDropsTest extends AbstractGQLTest{
     
     @Override
     protected String getValidRequest(){
-	    return "{\"extensions\":{\"persistedQuery\":{\"sha256Hash\":\"9a62a09bce5b53e26e64a671e530bc599cb6aab1e5ba3cbd5d85966d3940716f\",\"version\":1}},\"operationName\":\"DropsHighlightService_AvailableDrops\",\"variables\":{\"channelID\":\"%s\"}}".formatted(STREAMER_ID);
+	    return "{\"extensions\":{\"persistedQuery\":{\"sha256Hash\":\"962510a535f25f33bbf85d7767982e3bb6d1b00f84dd3c7a06d8572323dfd010\",\"version\":1}},\"operationName\":\"DropsHighlightService_AvailableDrops\",\"variables\":{\"channelID\":\"%s\"}}".formatted(STREAMER_ID);
     }
 }

--- a/miner/src/test/java/fr/rakambda/channelpointsminer/miner/api/gql/gql/GQLChannelFollowsTest.java
+++ b/miner/src/test/java/fr/rakambda/channelpointsminer/miner/api/gql/gql/GQLChannelFollowsTest.java
@@ -138,6 +138,16 @@ class GQLChannelFollowsTest extends AbstractGQLTest{
 	}
 	
 	@Test
+	void getAllFollowsStopsWhenEmptyResponse(){
+		expectBodyRequestOkWithIntegrityOk(VALID_QUERY.formatted(ALL_LIMIT, ORDER), "api/gql/gql/channelFollows_severalFollows.json");
+		expectGqlRequest(VALID_QUERY_WITH_CURSOR.formatted("cursor-id-2", ALL_LIMIT, ORDER), 403, null);
+		
+		assertThat(tested.allChannelFollows()).hasSize(2);
+		
+		verifyAll();
+	}
+	
+	@Test
 	void getAllFollowsErrorGettingCursor(){
 		expectBodyRequestOkWithIntegrityOk(VALID_QUERY.formatted(ALL_LIMIT, ORDER), "api/gql/gql/channelFollows_invalidCursor.json");
 		

--- a/miner/src/test/java/fr/rakambda/channelpointsminer/miner/streamer/StreamerSettingsTest.java
+++ b/miner/src/test/java/fr/rakambda/channelpointsminer/miner/streamer/StreamerSettingsTest.java
@@ -22,6 +22,7 @@ class StreamerSettingsTest{
 				.makePredictions(true)
 				.participateCampaigns(true)
 				.followRaid(true)
+				.excludeSubscriberDrops(false)
 				.joinIrc(true)
 				.index(24)
 				.priorities(List.of(priority))
@@ -34,6 +35,7 @@ class StreamerSettingsTest{
 		assertThat(copy.isEnabled()).isEqualTo(tested.isEnabled());
 		assertThat(copy.isMakePredictions()).isEqualTo(tested.isMakePredictions());
 		assertThat(copy.isParticipateCampaigns()).isEqualTo(tested.isParticipateCampaigns());
+		assertThat(copy.isExcludeSubscriberDrops()).isEqualTo(tested.isExcludeSubscriberDrops());
 		assertThat(copy.isFollowRaid()).isEqualTo(tested.isFollowRaid());
 		assertThat(copy.isJoinIrc()).isEqualTo(tested.isJoinIrc());
 		assertThat(copy.getIndex()).isEqualTo(tested.getIndex());

--- a/miner/src/test/java/fr/rakambda/channelpointsminer/miner/streamer/StreamerTest.java
+++ b/miner/src/test/java/fr/rakambda/channelpointsminer/miner/streamer/StreamerTest.java
@@ -407,6 +407,12 @@ class StreamerTest{
 	}
 	
 	@Test
+	void excludeSubscriberDrops(){
+		when(settings.isExcludeSubscriberDrops()).thenReturn(true);
+		assertThat(tested.isExcludeSubscriberDrops()).isTrue();
+	}
+	
+	@Test
 	void doesNotFollowRaid(){
 		when(settings.isFollowRaid()).thenReturn(false);
 		assertThat(tested.followRaids()).isFalse();

--- a/miner/src/test/resources/api/gql/gql/dropsHighlightServiceAvailableDrops_withDrops.json
+++ b/miner/src/test/resources/api/gql/gql/dropsHighlightServiceAvailableDrops_withDrops.json
@@ -42,6 +42,10 @@
               "__typename": "TimeBasedDrop"
             }
           ],
+          "summary": {
+            "includesSubRequirement": true,
+            "__typename": "DropCampaignSummary"
+          },
           "__typename": "DropCampaign"
         }
       ],


### PR DESCRIPTION
## Pull Request Etiquette

Thanks to @jabbink on Discord

### Checklist

- [x] Tests have been added in relevant areas
- [ ] Corresponding changes made to the documentation (README.adoc) <!-- (if irrelevant check the box too) -->

### Type of change
Bug fix
New Feature
<!-- Choose one from "Bug fix" / "New Feature" / "Breaking change" / "Internal change" -->

## Description
Some drops can now be restricted for subscribers, this adds an option to ignore or not those drops. By default subscriber drops will nbe ignored.

Also fix some drops being stuck trying to be claimed even though they already are.
