### PR TITLE
Drops: Re-used BenefitEdge may be of interest

### DIFF
--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/api/gql/gql/data/types/UserDropReward.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/api/gql/gql/data/types/UserDropReward.java
@@ -2,6 +2,8 @@ package fr.rakambda.channelpointsminer.miner.api.gql.gql.data.types;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import fr.rakambda.channelpointsminer.miner.util.json.ISO8601ZonedDateTimeDeserializer;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -9,6 +11,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import java.time.ZonedDateTime;
 
 @JsonTypeName("UserDropReward")
 @Getter
@@ -23,4 +27,8 @@ public class UserDropReward extends GQLType{
 	private String id;
 	@JsonProperty("totalCount")
 	private int totalCount;
+	@JsonProperty("lastAwardedAt")
+	@JsonDeserialize(using = ISO8601ZonedDateTimeDeserializer.class)
+	@Nullable
+	private ZonedDateTime lastAwardedAt;
 }

--- a/miner/src/test/java/fr/rakambda/channelpointsminer/miner/api/gql/gql/GQLApiInventoryTest.java
+++ b/miner/src/test/java/fr/rakambda/channelpointsminer/miner/api/gql/gql/GQLApiInventoryTest.java
@@ -79,6 +79,7 @@ class GQLApiInventoryTest extends AbstractGQLTest{
 												UserDropReward.builder()
 														.id("reward-id")
 														.totalCount(1)
+														.lastAwardedAt(ZonedDateTime.of(2021, 10, 31, 21, 41, 34, 0, UTC))
 														.build()
 										))
 										.build())

--- a/miner/src/test/java/fr/rakambda/channelpointsminer/miner/priority/DropsPriorityTest.java
+++ b/miner/src/test/java/fr/rakambda/channelpointsminer/miner/priority/DropsPriorityTest.java
@@ -231,9 +231,23 @@ class DropsPriorityTest{
 		try(var timeFactory = mockStatic(TimeFactory.class)){
 			timeFactory.when(TimeFactory::nowZoned).thenReturn(NOW);
 			
+			when(userDropReward.getLastAwardedAt()).thenReturn(NOW.plusSeconds(1));
 			when(userDropReward.getTotalCount()).thenReturn(DROP_CLAIM_LIMIT);
 			
 			assertThat(tested.getScore(miner, streamer)).isEqualTo(0);
+		}
+	}
+	
+	@Test
+	void claimLimitNotReachedOnReusedDropReward(){
+		try(var timeFactory = mockStatic(TimeFactory.class)){
+			timeFactory.when(TimeFactory::nowZoned).thenReturn(NOW);
+			
+			when(timeBasedDrop.getStartAt()).thenReturn(NOW);
+			when(userDropReward.getLastAwardedAt()).thenReturn(NOW.minusSeconds(1));
+			when(userDropReward.getTotalCount()).thenReturn(DROP_CLAIM_LIMIT);
+			
+			assertThat(tested.getScore(miner, streamer)).isEqualTo(SCORE);
 		}
 	}
 	


### PR DESCRIPTION
## Pull Request Etiquette

### Checklist

- [x] Tests have been added in relevant areas
- [x] Corresponding changes made to the documentation (README.adoc) <!-- (if irrelevant check the box too) -->

### Type of change

<!-- Choose one from "Bug fix" / "New Feature" / "Breaking change" / "Internal change" -->
Bug fix

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Check last awarded time in inventory prior to dismissing drops based on the claim limit. Some publishers reuse the same BenefitEdge/Drop over and over again while being fungible drops in their respective games (e.g. Hearthstone card packs being all "the same" according to the drop settings on twitch, but offering different contents in the game itself)