### PR TITLE
Fix incorrect watch time tracking

### DIFF
--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/runnable/SendM3u8MinutesWatched.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/runnable/SendM3u8MinutesWatched.java
@@ -31,4 +31,9 @@ public class SendM3u8MinutesWatched extends SendMinutesWatched{
 		}
 		return result;
 	}
+	
+	@Override
+	protected boolean shouldUpdateWatchedMinutes(){
+		return false;
+	}
 }

--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/runnable/SendMinutesWatched.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/runnable/SendMinutesWatched.java
@@ -27,6 +27,8 @@ public abstract class SendMinutesWatched implements Runnable{
 	protected abstract boolean checkStreamer(@NotNull Streamer streamer);
 	
 	protected abstract boolean send(@NotNull Streamer streamer);
+
+	protected abstract boolean shouldUpdateWatchedMinutes();
 	
 	@Override
 	public void run(){
@@ -46,7 +48,7 @@ public abstract class SendMinutesWatched implements Runnable{
 			for(var streamer : toSendMinutesWatched){
 				try(var ignored2 = LogContext.empty().withStreamer(streamer)){
 					log.debug("Sending {} minutes watched", getType());
-					if(send(streamer)){
+					if(send(streamer) && shouldUpdateWatchedMinutes()){
 						updateWatchedMinutes(streamer);
 					}
 					CommonUtils.randomSleep(100, 50);

--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/runnable/SendSpadeMinutesWatched.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/runnable/SendSpadeMinutesWatched.java
@@ -47,4 +47,9 @@ public class SendSpadeMinutesWatched extends SendMinutesWatched{
 		
 		return miner.getTwitchApi().sendPlayerEvents(streamer.getSpadeUrl(), request);
 	}
+	
+	@Override
+	protected boolean shouldUpdateWatchedMinutes(){
+		return true;
+	}
 }

--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/runnable/UpdateStreamInfo.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/runnable/UpdateStreamInfo.java
@@ -52,7 +52,9 @@ public class UpdateStreamInfo implements Runnable{
 			var now = TimeFactory.now();
 			streamer.setLastUpdated(now);
 			if(wasStreaming && !streamer.isStreaming()){
-				streamer.setLastOffline(now);
+				if (streamer.getWatchedDuration().compareTo(Streamer.SEVEN_MINUTES) > 0){
+					streamer.setLastOffline(now);
+				}
 				streamer.resetWatchedDuration();
 			}
 		}

--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/streamer/Streamer.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/streamer/Streamer.java
@@ -40,7 +40,7 @@ import static java.util.Optional.ofNullable;
 @ToString(onlyExplicitlyIncluded = true)
 @Log4j2
 public class Streamer{
-	private static final Duration SEVEN_MINUTES = Duration.ofMinutes(7);
+	public static final Duration SEVEN_MINUTES = Duration.ofMinutes(7);
 	
 	@NotNull
 	@Getter

--- a/miner/src/test/java/fr/rakambda/channelpointsminer/miner/runnable/SendMinutesWatchedTest.java
+++ b/miner/src/test/java/fr/rakambda/channelpointsminer/miner/runnable/SendMinutesWatchedTest.java
@@ -305,5 +305,10 @@ class SendMinutesWatchedTest{
 			}
 			return sendResult;
 		}
+		
+		@Override
+		protected boolean shouldUpdateWatchedMinutes(){
+			return true;
+		}
 	}
 }

--- a/miner/src/test/java/fr/rakambda/channelpointsminer/miner/runnable/UpdateStreamInfoTest.java
+++ b/miner/src/test/java/fr/rakambda/channelpointsminer/miner/runnable/UpdateStreamInfoTest.java
@@ -149,6 +149,7 @@ class UpdateStreamInfoTest{
 		try(var timeFactory = mockStatic(TimeFactory.class)){
 			timeFactory.when(TimeFactory::now).thenReturn(NOW);
 			
+			when(streamer.getWatchedDuration()).thenReturn(Streamer.SEVEN_MINUTES.plusSeconds(1));
 			when(streamer.isStreaming()).thenReturn(true).thenReturn(false);
 			when(gqlApi.videoPlayerStreamInfoOverlayChannel(STREAMER_USERNAME)).thenReturn(Optional.empty());
 			when(gqlApi.channelPointsContext(STREAMER_USERNAME)).thenReturn(Optional.empty());


### PR DESCRIPTION
## Pull Request Etiquette

### Checklist

- [ ] Tests have been added in relevant areas
- [x] Corresponding changes made to the documentation (README.adoc) <!-- (if irrelevant check the box too) -->

### Type of change

<!-- Choose one from "Bug fix" / "New Feature" / "Breaking change" / "Internal change" -->
Bug fix

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
There are two issues with watch time tracking that result in missed WATCH_STREAK events:

1. Both SendMinutesWatched instances increase the watchtime despite one triggering 4 times a minute, and one once a minute, increasing watchtime by 5 minutes per minute. This change prevents the M3U8 tracker (4 times a minute) to increase watch time in the internal counter
2. Sometimes streamers go live for a minute, something breaks, they stop, and restart quickly. This would reset last offline immediately, preventing the next go-live to be seen as eligible for a WATCH_STREAK. This PR will only reset the last offline tracker if we have watched them for long enough.