### PR TITLE
Split channel point farming and drop farming into separate behaviours

### DIFF
--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/runnable/SendM3u8MinutesWatched.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/runnable/SendM3u8MinutesWatched.java
@@ -36,4 +36,9 @@ public class SendM3u8MinutesWatched extends SendMinutesWatched{
 	protected boolean shouldUpdateWatchedMinutes(){
 		return false;
 	}
+	
+	@Override
+	protected boolean shouldWatchDropsOnly(){
+		return true;
+	}
 }

--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/runnable/SendMinutesWatched.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/runnable/SendMinutesWatched.java
@@ -30,18 +30,21 @@ public abstract class SendMinutesWatched implements Runnable{
 
 	protected abstract boolean shouldUpdateWatchedMinutes();
 	
+	protected abstract boolean shouldWatchDropsOnly();
+	
 	@Override
 	public void run(){
 		log.debug("Starting sending {} minutes watched", getType());
 		
 		try(var ignored = LogContext.with(miner)){
+			var dropsOnly = shouldWatchDropsOnly();
 			var toSendMinutesWatched = miner.getStreamers().stream()
 					.filter(Streamer::isStreaming)
 					.filter(streamer -> !streamer.isChatBanned())
 					.filter(this::checkStreamer)
-					.map(streamer -> Map.entry(streamer, streamer.getScore(miner)))
+					.map(streamer -> Map.entry(streamer, streamer.getScore(miner, !dropsOnly)))
 					.sorted(this::compare)
-					.limit(2)
+					.limit(dropsOnly ? 1 : 2)
 					.map(Map.Entry::getKey)
 					.toList();
 			

--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/runnable/SendSpadeMinutesWatched.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/runnable/SendSpadeMinutesWatched.java
@@ -52,4 +52,9 @@ public class SendSpadeMinutesWatched extends SendMinutesWatched{
 	protected boolean shouldUpdateWatchedMinutes(){
 		return true;
 	}
+	
+	@Override
+	protected boolean shouldWatchDropsOnly(){
+		return false;
+	}
 }

--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/streamer/Streamer.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/streamer/Streamer.java
@@ -15,6 +15,7 @@ import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.videoplayerstreamin
 import fr.rakambda.channelpointsminer.miner.factory.TimeFactory;
 import fr.rakambda.channelpointsminer.miner.log.LogContext;
 import fr.rakambda.channelpointsminer.miner.miner.IMiner;
+import fr.rakambda.channelpointsminer.miner.priority.DropsPriority;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -109,9 +110,10 @@ public class Streamer{
 		return TimeFactory.now().isAfter(lastUpdated.plus(5, MINUTES));
 	}
 	
-	public int getScore(@NotNull IMiner miner){
+	public int getScore(@NotNull IMiner miner, boolean ignoreDropsPriority){
 		try(var ignored = LogContext.with(miner).withStreamer(this)){
 			var score = settings.getPriorities().stream()
+					.filter(priority -> ignoreDropsPriority != (priority instanceof DropsPriority))
 					.mapToInt(p -> {
 						var s = p.getScore(miner, this);
 						if(s != 0){

--- a/miner/src/test/java/fr/rakambda/channelpointsminer/miner/runnable/SendMinutesWatchedTest.java
+++ b/miner/src/test/java/fr/rakambda/channelpointsminer/miner/runnable/SendMinutesWatchedTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import java.net.MalformedURLException;
-import java.net.URL;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.LinkedList;
@@ -208,25 +207,23 @@ class SendMinutesWatchedTest{
 		
 		var s1 = mock(Streamer.class);
 		when(s1.isStreaming()).thenReturn(true);
-		when(s1.getScore(miner)).thenReturn(10);
+		when(s1.getScore(miner, true)).thenReturn(10);
 		
-		var spade2 = new URL("https://spade2");
 		var s2 = mock(Streamer.class);
 		when(s2.getId()).thenReturn("s2");
 		when(s2.getUsername()).thenReturn("sn2");
 		when(s2.isStreaming()).thenReturn(true);
-		when(s2.getScore(miner)).thenReturn(100);
+		when(s2.getScore(miner, true)).thenReturn(100);
 		
 		var s3 = mock(Streamer.class);
 		when(s3.isStreaming()).thenReturn(true);
-		when(s3.getScore(miner)).thenReturn(20);
+		when(s3.getScore(miner, true)).thenReturn(20);
 		
-		var spade4 = new URL("https://spade4");
 		var s4 = mock(Streamer.class);
 		when(s4.getId()).thenReturn("s4");
 		when(s4.getUsername()).thenReturn("sn4");
 		when(s4.isStreaming()).thenReturn(true);
-		when(s4.getScore(miner)).thenReturn(50);
+		when(s4.getScore(miner, true)).thenReturn(50);
 		
 		when(miner.getStreamers()).thenReturn(List.of(s1, s2, s3, s4));
 		
@@ -240,29 +237,27 @@ class SendMinutesWatchedTest{
 		
 		var s1 = mock(Streamer.class);
 		when(s1.isStreaming()).thenReturn(true);
-		when(s1.getScore(miner)).thenReturn(10);
+		when(s1.getScore(miner, true)).thenReturn(10);
 		when(s1.getIndex()).thenReturn(1);
 		
-		var spade2 = new URL("https://spade2");
 		var s2 = mock(Streamer.class);
 		when(s2.getId()).thenReturn("s2");
 		when(s2.getUsername()).thenReturn("sn2");
 		when(s2.isStreaming()).thenReturn(true);
 		when(s2.getIndex()).thenReturn(0);
-		when(s2.getScore(miner)).thenReturn(10);
+		when(s2.getScore(miner, true)).thenReturn(10);
 		
 		var s3 = mock(Streamer.class);
 		when(s3.isStreaming()).thenReturn(true);
-		when(s3.getScore(miner)).thenReturn(10);
+		when(s3.getScore(miner, true)).thenReturn(10);
 		when(s3.getIndex()).thenReturn(25);
 		
-		var spade4 = new URL("https://spade4");
 		var s4 = mock(Streamer.class);
 		when(s4.getId()).thenReturn("s4");
 		when(s4.getUsername()).thenReturn("sn4");
 		when(s4.isStreaming()).thenReturn(true);
 		when(s4.getIndex()).thenReturn(-5);
-		when(s4.getScore(miner)).thenReturn(10);
+		when(s4.getScore(miner, true)).thenReturn(10);
 		
 		when(miner.getStreamers()).thenReturn(List.of(s1, s2, s3, s4));
 		
@@ -309,6 +304,11 @@ class SendMinutesWatchedTest{
 		@Override
 		protected boolean shouldUpdateWatchedMinutes(){
 			return true;
+		}
+		
+		@Override
+		protected boolean shouldWatchDropsOnly(){
+			return false;
 		}
 	}
 }

--- a/miner/src/test/java/fr/rakambda/channelpointsminer/miner/streamer/StreamerTest.java
+++ b/miner/src/test/java/fr/rakambda/channelpointsminer/miner/streamer/StreamerTest.java
@@ -416,7 +416,7 @@ class StreamerTest{
 	@Test
 	void getScoreNoPriorities(){
 		when(settings.getPriorities()).thenReturn(List.of());
-		assertThat(tested.getScore(miner)).isEqualTo(0);
+		assertThat(tested.getScore(miner, true)).isEqualTo(0);
 	}
 	
 	@Test
@@ -431,7 +431,7 @@ class StreamerTest{
 		when(p2.getScore(miner, tested)).thenReturn(s2);
 		
 		when(settings.getPriorities()).thenReturn(List.of(p1, p2));
-		assertThat(tested.getScore(miner)).isEqualTo(s1 + s2);
+		assertThat(tested.getScore(miner, true)).isEqualTo(s1 + s2);
 	}
 	
 	@ParameterizedTest


### PR DESCRIPTION
## Pull Request Etiquette

### Checklist

- [ ] Tests have been added in relevant areas
- [x] Corresponding changes made to the documentation (README.adoc) <!-- (if irrelevant check the box too) -->

### Type of change

<!-- Choose one from "Bug fix" / "New Feature" / "Breaking change" / "Internal change" -->
New feature and breaking change  
Nothing changes in configuration, but if a user wants to farm channel points specifically for channels with drops enabled, this will break their workflow. I don't think anyone would want to do that but you never know. To me it is more logical to just get drops, and then, if the priority is high enough based on other things, get channel points there as well, or on a totally different channel.

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
New logic:
- Watch highest priority drops enabled streamer via M3U8
- Watch two highest-priority, ignoring Drops, streamer via Spade

Can effectively "watch" 3 different streams, giving channel points on 2 according to ALL priority settings except for DropsPriority, and one solely according to DropsPriority.
