### PR TITLE
Add setting to dismiss known global ids that hide normal drops

### DIFF
--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/api/gql/gql/GQLApi.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/api/gql/gql/GQLApi.java
@@ -27,6 +27,8 @@ import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.makeprediction.Make
 import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.makeprediction.MakePredictionOperation;
 import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.reportmenuitem.ReportMenuItemData;
 import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.reportmenuitem.ReportMenuItemOperation;
+import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.setdropscommunityhighlighttohidden.SetDropsCommunityHighlightToHiddenData;
+import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.setdropscommunityhighlighttohidden.SetDropsCommunityHighlightToHiddenOperation;
 import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.types.FollowConnection;
 import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.types.FollowEdge;
 import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.types.PageInfo;
@@ -157,6 +159,11 @@ public class GQLApi{
     public Optional<GQLResponse<DropsHighlightServiceAvailableDropsData>> dropsHighlightServiceAvailableDrops(@NotNull String channelId){
         return postGqlRequest(new DropsHighlightServiceAvailableDropsOperation(channelId));
     }
+	
+	@NotNull
+	public Optional<GQLResponse<SetDropsCommunityHighlightToHiddenData>> setDropsCommunityHighlightToHidden(@NotNull String channelId, @NotNull String campaignId){
+		return postGqlRequest(new SetDropsCommunityHighlightToHiddenOperation(channelId, campaignId));
+	}
     
     @NotNull
     public Optional<GQLResponse<ClaimCommunityPointsData>> claimCommunityPoints(@NotNull String channelId, @NotNull String claimId){

--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/api/gql/gql/data/setdropscommunityhighlighttohidden/InputData.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/api/gql/gql/data/setdropscommunityhighlighttohidden/InputData.java
@@ -1,0 +1,22 @@
+package fr.rakambda.channelpointsminer.miner.api.gql.gql.data.setdropscommunityhighlighttohidden;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EqualsAndHashCode
+@ToString
+public class InputData{
+	@JsonProperty("channelID")
+	private String channelID;
+	@JsonProperty("campaignID")
+	private String campaignID;
+}

--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/api/gql/gql/data/setdropscommunityhighlighttohidden/InputData.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/api/gql/gql/data/setdropscommunityhighlighttohidden/InputData.java
@@ -15,8 +15,8 @@ import lombok.ToString;
 @EqualsAndHashCode
 @ToString
 public class InputData{
-	@JsonProperty("channelID")
-	private String channelID;
 	@JsonProperty("campaignID")
 	private String campaignID;
+	@JsonProperty("channelID")
+	private String channelID;
 }

--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/api/gql/gql/data/setdropscommunityhighlighttohidden/SetDropsCommunityHighlightToHiddenData.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/api/gql/gql/data/setdropscommunityhighlighttohidden/SetDropsCommunityHighlightToHiddenData.java
@@ -1,0 +1,23 @@
+package fr.rakambda.channelpointsminer.miner.api.gql.gql.data.setdropscommunityhighlighttohidden;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.types.SetDropsCommunityHighlightToHiddenPayload;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.jetbrains.annotations.Nullable;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EqualsAndHashCode
+@ToString
+public class SetDropsCommunityHighlightToHiddenData{
+	@JsonProperty("setDropsCommunityHighlightToHidden")
+	@Nullable
+	private SetDropsCommunityHighlightToHiddenPayload setDropsCommunityHighlightToHiddenPayload;
+}

--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/api/gql/gql/data/setdropscommunityhighlighttohidden/SetDropsCommunityHighlightToHiddenOperation.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/api/gql/gql/data/setdropscommunityhighlighttohidden/SetDropsCommunityHighlightToHiddenOperation.java
@@ -1,0 +1,27 @@
+package fr.rakambda.channelpointsminer.miner.api.gql.gql.data.setdropscommunityhighlighttohidden;
+
+import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.GQLResponse;
+import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.IGQLOperation;
+import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.PersistedQueryExtension;
+import kong.unirest.core.GenericType;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import org.jetbrains.annotations.NotNull;
+
+@Getter
+@EqualsAndHashCode(callSuper = true)
+@ToString
+public class SetDropsCommunityHighlightToHiddenOperation extends IGQLOperation<SetDropsCommunityHighlightToHiddenData>{
+	public SetDropsCommunityHighlightToHiddenOperation(@NotNull String channelId, @NotNull String campaignID){
+		super("SetDropsCommunityHighlightToHidden");
+		addPersistedQueryExtension(new PersistedQueryExtension(1, "9dfaa13dbc7d178a35c0a038a270fad4b7bc1d0e1d404a18aed9b26ee797a697"));
+		addVariable("input", InputData.builder().channelID(channelId).campaignID(campaignID).build());
+	}
+	
+	@Override
+	@NotNull
+	public GenericType<GQLResponse<SetDropsCommunityHighlightToHiddenData>> getResponseType(){
+		return new GenericType<>(){};
+	}
+}

--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/api/gql/gql/data/types/GQLType.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/api/gql/gql/data/types/GQLType.java
@@ -33,6 +33,7 @@ import lombok.Getter;
         @JsonSubTypes.Type(value = ClaimCommunityMomentPayload.class, name = "ClaimCommunityMomentPayload"),
         @JsonSubTypes.Type(value = StreamPlaybackAccessToken.class, name = "PlaybackAccessToken"),
         @JsonSubTypes.Type(value = DropCampaignSummary.class, name = "DropCampaignSummary"),
+        @JsonSubTypes.Type(value = SetDropsCommunityHighlightToHiddenPayload.class, name = "SetDropsCommunityHighlightToHiddenPayload"),
 })
 @EqualsAndHashCode
 public abstract class GQLType{

--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/api/gql/gql/data/types/SetDropsCommunityHighlightToHiddenPayload.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/api/gql/gql/data/types/SetDropsCommunityHighlightToHiddenPayload.java
@@ -1,0 +1,22 @@
+package fr.rakambda.channelpointsminer.miner.api.gql.gql.data.types;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@JsonTypeName("SetDropsCommunityHighlightToHiddenPayload")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EqualsAndHashCode(callSuper = true)
+@ToString
+public class SetDropsCommunityHighlightToHiddenPayload extends GQLType{
+	@JsonProperty("isHidden")
+	private boolean isHidden;
+}

--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/runnable/UpdateStreamInfo.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/runnable/UpdateStreamInfo.java
@@ -2,6 +2,11 @@ package fr.rakambda.channelpointsminer.miner.runnable;
 
 import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.GQLResponse;
 import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.chatroombanstatus.ChatRoomBanStatusData;
+import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.dropshighlightserviceavailabledrops.DropsHighlightServiceAvailableDropsData;
+import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.setdropscommunityhighlighttohidden.SetDropsCommunityHighlightToHiddenData;
+import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.types.Channel;
+import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.types.DropCampaign;
+import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.types.SetDropsCommunityHighlightToHiddenPayload;
 import fr.rakambda.channelpointsminer.miner.factory.TimeFactory;
 import fr.rakambda.channelpointsminer.miner.log.LogContext;
 import fr.rakambda.channelpointsminer.miner.miner.IMiner;
@@ -10,12 +15,16 @@ import fr.rakambda.channelpointsminer.miner.util.CommonUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.jetbrains.annotations.NotNull;
+import java.util.Collection;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 @Log4j2
 @RequiredArgsConstructor
 public class UpdateStreamInfo implements Runnable{
+	private static final Collection<String> DISMISSIBLE_CAMPAIGNS = Set.of("dc4ff0b4-4de0-11ef-9ec3-621fb0811846");
+	
 	@NotNull
 	private final IMiner miner;
 	
@@ -52,7 +61,7 @@ public class UpdateStreamInfo implements Runnable{
 			var now = TimeFactory.now();
 			streamer.setLastUpdated(now);
 			if(wasStreaming && !streamer.isStreaming()){
-				if (streamer.hasStreamedEnoughTime()){
+				if(streamer.hasStreamedEnoughTime()){
 					streamer.setLastOffline(now);
 				}
 				streamer.resetWatchedDuration();
@@ -130,14 +139,36 @@ public class UpdateStreamInfo implements Runnable{
 	private void updateCampaigns(@NotNull Streamer streamer){
 		log.trace("Updating campaigns");
 		if(streamer.isParticipateCampaigns() && streamer.isStreaming() && streamer.isStreamingGame()){
-			miner.getGqlApi().dropsHighlightServiceAvailableDrops(streamer.getId())
-					.map(GQLResponse::getData)
-					.ifPresentOrElse(
-							streamer::setDropsHighlightServiceAvailableDrops,
-							() -> streamer.setDropsHighlightServiceAvailableDrops(null));
+			var dropsHighlightServiceAvailableDropsData = miner.getGqlApi().dropsHighlightServiceAvailableDrops(streamer.getId())
+					.map(GQLResponse::getData);
+			
+			dropsHighlightServiceAvailableDropsData.ifPresentOrElse(
+					streamer::setDropsHighlightServiceAvailableDrops,
+					() -> streamer.setDropsHighlightServiceAvailableDrops(null));
+			
+			if(streamer.isDismissKnownGlobalCampaigns()){
+				dropsHighlightServiceAvailableDropsData.stream()
+						.map(DropsHighlightServiceAvailableDropsData::getChannel)
+						.map(Channel::getViewerDropCampaigns)
+						.flatMap(Collection::stream)
+						.filter(dropCampaign -> DISMISSIBLE_CAMPAIGNS.contains(dropCampaign.getId()))
+						.forEach(dropCampaign -> dismissCampaign(miner, streamer, dropCampaign));
+			}
 		}
 		else{
 			streamer.setDropsHighlightServiceAvailableDrops(null);
 		}
+	}
+	
+	private void dismissCampaign(@NotNull IMiner miner, @NotNull Streamer streamer, @NotNull DropCampaign dropCampaign){
+		var result = miner.getGqlApi().setDropsCommunityHighlightToHidden(streamer.getId(), dropCampaign.getId());
+		var isHidden = result
+				.map(GQLResponse::getData)
+				.map(SetDropsCommunityHighlightToHiddenData::getSetDropsCommunityHighlightToHiddenPayload)
+				.map(SetDropsCommunityHighlightToHiddenPayload::isHidden)
+				.orElse(false);
+		
+		log.info("Dismissed campaign {} on streamer {}, result {}", dropCampaign, streamer, isHidden);
+		miner.updateStreamerInfos(streamer);
 	}
 }

--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/streamer/Streamer.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/streamer/Streamer.java
@@ -206,6 +206,10 @@ public class Streamer{
 		return settings.isParticipateCampaigns();
 	}
 	
+	public boolean isDismissKnownGlobalCampaigns(){
+		return settings.isDismissKnownGlobalCampaigns();
+	}
+	
 	public boolean isStreamingGame(){
 		return getGame()
 				.map(Game::getName)

--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/streamer/StreamerSettings.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/streamer/StreamerSettings.java
@@ -43,6 +43,10 @@ public class StreamerSettings{
 	@JsonPropertyDescription("Participate in campaigns and claim rewards (drops). Default: false")
 	@Builder.Default
 	private boolean participateCampaigns = false;
+	@JsonProperty("dismissKnownGlobalCampaigns")
+	@JsonPropertyDescription("Dismiss known global campaigns that blocks other drops from being seen. Default: false")
+	@Builder.Default
+	private boolean dismissKnownGlobalCampaigns = false;
 	@JsonProperty("claimMoments")
 	@JsonPropertyDescription("Claim moments. Default: false")
 	@Builder.Default
@@ -77,6 +81,7 @@ public class StreamerSettings{
 		makePredictions = origin.makePredictions;
 		followRaid = origin.followRaid;
 		participateCampaigns = origin.participateCampaigns;
+		dismissKnownGlobalCampaigns = origin.dismissKnownGlobalCampaigns;
 		joinIrc = origin.joinIrc;
 		excludeSubscriberDrops = origin.excludeSubscriberDrops;
 		index = origin.index;

--- a/miner/src/test/java/fr/rakambda/channelpointsminer/miner/api/gql/gql/GQLApiSetDropsCommunityHighlightToHiddenTest.java
+++ b/miner/src/test/java/fr/rakambda/channelpointsminer/miner/api/gql/gql/GQLApiSetDropsCommunityHighlightToHiddenTest.java
@@ -1,0 +1,47 @@
+package fr.rakambda.channelpointsminer.miner.api.gql.gql;
+
+import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.GQLResponse;
+import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.setdropscommunityhighlighttohidden.SetDropsCommunityHighlightToHiddenData;
+import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.types.SetDropsCommunityHighlightToHiddenPayload;
+import fr.rakambda.channelpointsminer.miner.tests.UnirestMockExtension;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import java.util.Map;
+import java.util.Optional;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(UnirestMockExtension.class)
+class GQLApiSetDropsCommunityHighlightToHiddenTest extends AbstractGQLTest{
+	private static final String CAMPAIGN_ID = "campaign-id";
+	private static final String CHANNEL_ID = "channel-id";
+	
+	@Test
+	void nominalClaimed(){
+		var expected = GQLResponse.<SetDropsCommunityHighlightToHiddenData> builder()
+				.extensions(Map.of(
+						"durationMilliseconds", 9,
+						"operationName", "SetDropsCommunityHighlightToHidden",
+						"requestID", "request-id"
+				))
+				.data(SetDropsCommunityHighlightToHiddenData.builder()
+						.setDropsCommunityHighlightToHiddenPayload(SetDropsCommunityHighlightToHiddenPayload.builder()
+								.isHidden(true)
+								.build())
+						.build())
+				.build();
+		
+		expectValidRequestOkWithIntegrityOk("api/gql/gql/setDropsCommunityHighlightToHidden_success.json");
+		
+		var actual = tested.setDropsCommunityHighlightToHidden(CHANNEL_ID, CAMPAIGN_ID);
+		assertThat(actual).contains(expected);
+		
+		verifyAll();
+	}
+	
+	@Override
+	protected String getValidRequest(){
+		return "{\"extensions\":{\"persistedQuery\":{\"sha256Hash\":\"9dfaa13dbc7d178a35c0a038a270fad4b7bc1d0e1d404a18aed9b26ee797a697\",\"version\":1}},\"operationName\":\"SetDropsCommunityHighlightToHidden\",\"variables\":{\"input\":{\"campaignID\":\"%s\",\"channelID\":\"%s\"}}}".formatted(CAMPAIGN_ID, CHANNEL_ID);
+	}
+}

--- a/miner/src/test/java/fr/rakambda/channelpointsminer/miner/runnable/UpdateStreamInfoTest.java
+++ b/miner/src/test/java/fr/rakambda/channelpointsminer/miner/runnable/UpdateStreamInfoTest.java
@@ -6,7 +6,9 @@ import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.channelpointscontex
 import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.chatroombanstatus.ChatRoomBanStatusData;
 import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.dropshighlightserviceavailabledrops.DropsHighlightServiceAvailableDropsData;
 import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.playbackaccesstoken.PlaybackAccessTokenData;
+import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.types.Channel;
 import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.types.ChatRoomBanStatus;
+import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.types.DropCampaign;
 import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.types.StreamPlaybackAccessToken;
 import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.types.User;
 import fr.rakambda.channelpointsminer.miner.api.gql.gql.data.videoplayerstreaminfooverlaychannel.VideoPlayerStreamInfoOverlayChannelData;
@@ -48,6 +50,7 @@ class UpdateStreamInfoTest{
 	private static final String ACCOUNT_ID = "account-id";
 	private static final String M3U8_SIGNATURE = "signature";
 	private static final String M3U8_VALUE = "value";
+	private static final String CAMPAIGN_ID = "campaign-id";
 	
 	@InjectMocks
 	private UpdateStreamInfo tested;
@@ -82,6 +85,12 @@ class UpdateStreamInfoTest{
 	private ChatRoomBanStatusData chatRoomBanStatusData;
 	@Mock
 	private PlaybackAccessTokenData playbackAccessTokenData;
+	@Mock
+	private DropsHighlightServiceAvailableDropsData dropsHighlightServiceAvailableDropsData;
+	@Mock
+	private Channel channel;
+	@Mock
+	private DropCampaign dropCampaign;
 	
 	private URL spadeUrl;
 	private URL m3u8Url;
@@ -112,6 +121,11 @@ class UpdateStreamInfoTest{
 		lenient().when(videoPlayerStreamInfoOverlayChannelData.getUser()).thenReturn(user);
 		lenient().when(gqlResponseChatRoomBanStatus.getData()).thenReturn(chatRoomBanStatusData);
 		lenient().when(gqlResponsePlaybackAccessToken.getData()).thenReturn(playbackAccessTokenData);
+		
+		lenient().when(dropsHighlightServiceAvailableDrops.getData()).thenReturn(dropsHighlightServiceAvailableDropsData);
+		lenient().when(dropsHighlightServiceAvailableDropsData.getChannel()).thenReturn(channel);
+		lenient().when(channel.getViewerDropCampaigns()).thenReturn(List.of(dropCampaign));
+		lenient().when(dropCampaign.getId()).thenReturn(CAMPAIGN_ID);
 	}
 	
 	@Test
@@ -380,9 +394,6 @@ class UpdateStreamInfoTest{
 		try(var timeFactory = mockStatic(TimeFactory.class)){
 			timeFactory.when(TimeFactory::now).thenReturn(NOW);
 			
-			var data = mock(DropsHighlightServiceAvailableDropsData.class);
-			when(dropsHighlightServiceAvailableDrops.getData()).thenReturn(data);
-			
 			when(streamer.isStreaming()).thenReturn(true);
 			when(streamer.isParticipateCampaigns()).thenReturn(true);
 			when(streamer.isStreamingGame()).thenReturn(true);
@@ -406,7 +417,48 @@ class UpdateStreamInfoTest{
 			verify(streamer).setChannelPointsContext(channelPointsContextData);
 			verify(streamer, never()).setSpadeUrl(any());
 			verify(streamer, never()).setM3u8Url(any());
-			verify(streamer).setDropsHighlightServiceAvailableDrops(data);
+			verify(streamer).setDropsHighlightServiceAvailableDrops(dropsHighlightServiceAvailableDropsData);
+			verify(streamer).setLastUpdated(NOW);
+			verify(streamer).setChatBanned(false);
+			verify(streamer, never()).setLastOffline(any());
+			verify(streamer, never()).resetWatchedDuration();
+		}
+	}
+	
+	@Test
+	void updateWithDataStreamingUpdateCampaignDismissibleAndSettingActivated(){
+		try(var timeFactory = mockStatic(TimeFactory.class)){
+			timeFactory.when(TimeFactory::now).thenReturn(NOW);
+			
+			var dropId = "dc4ff0b4-4de0-11ef-9ec3-621fb0811846";
+			when(dropCampaign.getId()).thenReturn(dropId);
+			
+			when(streamer.isStreaming()).thenReturn(true);
+			when(streamer.isParticipateCampaigns()).thenReturn(true);
+			when(streamer.isDismissKnownGlobalCampaigns()).thenReturn(true);
+			when(streamer.isStreamingGame()).thenReturn(true);
+			when(streamer.getSpadeUrl()).thenReturn(spadeUrl);
+			when(streamer.getM3u8Url()).thenReturn(m3u8Url);
+			when(gqlApi.videoPlayerStreamInfoOverlayChannel(STREAMER_USERNAME)).thenReturn(Optional.of(gqlResponseVideoPlayer));
+			when(gqlApi.channelPointsContext(STREAMER_USERNAME)).thenReturn(Optional.of(gqlResponseChannelPoints));
+			when(gqlApi.dropsHighlightServiceAvailableDrops(STREAMER_ID)).thenReturn(Optional.of(dropsHighlightServiceAvailableDrops));
+			when(gqlApi.chatRoomBanStatus(STREAMER_ID, ACCOUNT_ID)).thenReturn(Optional.of(gqlResponseChatRoomBanStatus));
+			
+			assertDoesNotThrow(() -> tested.run());
+			
+			verify(gqlApi).videoPlayerStreamInfoOverlayChannel(STREAMER_USERNAME);
+			verify(gqlApi).channelPointsContext(STREAMER_USERNAME);
+			verify(gqlApi).dropsHighlightServiceAvailableDrops(STREAMER_ID);
+			verify(gqlApi).setDropsCommunityHighlightToHidden(STREAMER_ID, dropId);
+			verify(gqlApi).chatRoomBanStatus(STREAMER_ID, ACCOUNT_ID);
+			verify(gqlApi, never()).playbackAccessToken(anyString());
+			verify(twitchApi, never()).getSpadeUrl(any(URL.class));
+			
+			verify(streamer).setVideoPlayerStreamInfoOverlayChannel(videoPlayerStreamInfoOverlayChannelData);
+			verify(streamer).setChannelPointsContext(channelPointsContextData);
+			verify(streamer, never()).setSpadeUrl(any());
+			verify(streamer, never()).setM3u8Url(any());
+			verify(streamer).setDropsHighlightServiceAvailableDrops(dropsHighlightServiceAvailableDropsData);
 			verify(streamer).setLastUpdated(NOW);
 			verify(streamer).setChatBanned(false);
 			verify(streamer, never()).setLastOffline(any());

--- a/miner/src/test/java/fr/rakambda/channelpointsminer/miner/streamer/PredictionSettingsTest.java
+++ b/miner/src/test/java/fr/rakambda/channelpointsminer/miner/streamer/PredictionSettingsTest.java
@@ -26,7 +26,7 @@ class PredictionSettingsTest{
 	
 	@Test
 	void copy(){
-		var actions = List.of(this.predictionAction);
+		var actions = List.of(predictionAction);
 		var tested = PredictionSettings.builder()
 				.delayCalculator(delayCalculator)
 				.minimumPointsRequired(25)

--- a/miner/src/test/java/fr/rakambda/channelpointsminer/miner/streamer/StreamerSettingsTest.java
+++ b/miner/src/test/java/fr/rakambda/channelpointsminer/miner/streamer/StreamerSettingsTest.java
@@ -21,6 +21,7 @@ class StreamerSettingsTest{
 		var tested = StreamerSettings.builder()
 				.makePredictions(true)
 				.participateCampaigns(true)
+				.dismissKnownGlobalCampaigns(true)
 				.followRaid(true)
 				.excludeSubscriberDrops(false)
 				.joinIrc(true)
@@ -35,6 +36,7 @@ class StreamerSettingsTest{
 		assertThat(copy.isEnabled()).isEqualTo(tested.isEnabled());
 		assertThat(copy.isMakePredictions()).isEqualTo(tested.isMakePredictions());
 		assertThat(copy.isParticipateCampaigns()).isEqualTo(tested.isParticipateCampaigns());
+		assertThat(copy.isDismissKnownGlobalCampaigns()).isEqualTo(tested.isDismissKnownGlobalCampaigns());
 		assertThat(copy.isExcludeSubscriberDrops()).isEqualTo(tested.isExcludeSubscriberDrops());
 		assertThat(copy.isFollowRaid()).isEqualTo(tested.isFollowRaid());
 		assertThat(copy.isJoinIrc()).isEqualTo(tested.isJoinIrc());

--- a/miner/src/test/java/fr/rakambda/channelpointsminer/miner/streamer/StreamerTest.java
+++ b/miner/src/test/java/fr/rakambda/channelpointsminer/miner/streamer/StreamerTest.java
@@ -510,6 +510,16 @@ class StreamerTest{
 		assertThat(tested.isParticipateCampaigns()).isEqualTo(state);
 	}
 	
+	@ParameterizedTest
+	@ValueSource(booleans = {
+			true,
+			false
+	})
+	void isDismissKnownGlobalCampaigns(boolean state){
+		when(settings.isDismissKnownGlobalCampaigns()).thenReturn(state);
+		assertThat(tested.isDismissKnownGlobalCampaigns()).isEqualTo(state);
+	}
+	
 	@Test
 	void getIndex(){
 		var index = 6;

--- a/miner/src/test/resources/api/gql/gql/setDropsCommunityHighlightToHidden_success.json
+++ b/miner/src/test/resources/api/gql/gql/setDropsCommunityHighlightToHidden_success.json
@@ -1,0 +1,14 @@
+{
+  "data" : {
+    "setDropsCommunityHighlightToHidden" : {
+      "isHidden" : true,
+      "__typename": "SetDropsCommunityHighlightToHiddenPayload"
+    },
+    "__typename": "fake"
+  },
+  "extensions" : {
+    "durationMilliseconds" : 9,
+    "operationName" : "SetDropsCommunityHighlightToHidden",
+    "requestID" : "request-id"
+  }
+}

--- a/miner/src/test/resources/config/config-with-more-customization.json
+++ b/miner/src/test/resources/config/config-with-more-customization.json
@@ -14,7 +14,8 @@
       "defaultStreamerSettings" : {
         "makePredictions" : true,
         "followRaid" : true,
-        "participateCampaigns" : true
+        "participateCampaigns" : true,
+        "isDismissKnownGlobalCampaigns": true
       },
       "streamerConfigDirectories" : [
         {


### PR DESCRIPTION
## Pull Request Etiquette

Thanks @jabbink

### Checklist

- [x] Tests have been added in relevant areas
- [x] Corresponding changes made to the documentation (README.adoc) <!-- (if irrelevant check the box too) -->

### Type of change
New Feature
<!-- Choose one from "Bug fix" / "New Feature" / "Breaking change" / "Internal change" -->

## Description

Twitch is now pushing the Apple TV+ "drop" on every channel, which makes drop recognition impossible (available drops highlight service only returns 1 drop, the Apple TV+ one) there's this GQL request to dismiss a drop campaign which I personally call in DropsPriority whenever I run into a sub requirement only drop, or a reward campaign.