### PR TITLE
Also grab mp4 chunks from m3u8

### DIFF
--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/api/twitch/TwitchApi.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/api/twitch/TwitchApi.java
@@ -25,7 +25,7 @@ public class TwitchApi{
 	private static final Pattern SETTINGS_URL_PATTERN = Pattern.compile("(https://static.twitchcdn.net/config/settings.*?js|https://assets.twitch.tv/config/settings.*?.js)");
 	private static final Pattern SPADE_URL_PATTERN = Pattern.compile("\"spade(Url|_url)\":\"(.*?)\"");
 	private static final Pattern M3U8_STREAM_PATTERN = Pattern.compile("(https://[/\\-.:\\\\,\"=\\w]+\\.m3u8)", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
-	private static final Pattern M3U8_CHUNK_PATTERN = Pattern.compile("^(https://[/\\-.:\\\\,\"=\\w]+\\.ts(\\?[.\\w\\-/=&]+)?)", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
+	private static final Pattern M3U8_CHUNK_PATTERN = Pattern.compile("^(https://[/\\-.:\\\\,\"=\\w]+\\.(ts|mp4)(\\?[.\\w\\-/=&]+)?)", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
 	
 	private final UnirestInstance unirest;
 	


### PR DESCRIPTION
## Pull Request Etiquette

### Checklist

- [x] Tests have been added in relevant areas
- [x] Corresponding changes made to the documentation (README.adoc) <!-- (if irrelevant check the box too) -->

### Type of change
Bug fix
<!-- Choose one from "Bug fix" / "New Feature" / "Breaking change" / "Internal change" -->

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Apparently twitch now also provides mp4 URLs inside it's m3u8 playlist whereas before there was only ts files. This PR adds the ability to grab mp4 chunks to avoid the error "Failed to get streamer M3U8 chunk from playlist".