### PR TITLE
Listen to `BroadcastSettingsUpdate` message to circumvent missing `streamUp`/`streamDown` events

### DIFF
--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/api/pubsub/data/message/BroadcastSettingsUpdate.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/api/pubsub/data/message/BroadcastSettingsUpdate.java
@@ -1,0 +1,22 @@
+package fr.rakambda.channelpointsminer.miner.api.pubsub.data.message;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@JsonTypeName("broadcast_settings_update")
+@Getter
+@EqualsAndHashCode(callSuper = true)
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BroadcastSettingsUpdate extends IPubSubMessage{
+	@JsonProperty("channel_id")
+	private String channelId;
+}

--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/api/pubsub/data/message/IPubSubMessage.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/api/pubsub/data/message/IPubSubMessage.java
@@ -27,6 +27,7 @@ import lombok.ToString;
 		@JsonSubTypes.Type(value = DropProgress.class, name = "drop-progress"),
 		@JsonSubTypes.Type(value = DropClaim.class, name = "drop-claim"),
 		@JsonSubTypes.Type(value = ViewCount.class, name = "viewcount"),
+		@JsonSubTypes.Type(value = BroadcastSettingsUpdate.class, name = "broadcast_settings_update"),
 })
 @EqualsAndHashCode
 @ToString

--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/api/pubsub/data/request/topic/TopicName.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/api/pubsub/data/request/topic/TopicName.java
@@ -16,7 +16,8 @@ public enum TopicName{
 	PREDICTIONS_CHANNEL_V1("predictions-channel-v1", false),
 	ONSITE_NOTIFICATIONS("onsite-notifications", true),
 	COMMUNITY_MOMENTS_CHANNEL_V1("community-moments-channel-v1", false),
-	USER_DROP_EVENTS("user-drop-events", false);
+	USER_DROP_EVENTS("user-drop-events", false),
+	BROADCAST_SETTINGS_UPDATE("broadcast-settings-update", false);
 	
 	@Getter(onMethod_ = @JsonValue)
 	private final String value;

--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/handler/PubSubMessageHandlerAdapter.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/handler/PubSubMessageHandlerAdapter.java
@@ -1,5 +1,6 @@
 package fr.rakambda.channelpointsminer.miner.handler;
 
+import fr.rakambda.channelpointsminer.miner.api.pubsub.data.message.BroadcastSettingsUpdate;
 import fr.rakambda.channelpointsminer.miner.api.pubsub.data.message.ClaimAvailable;
 import fr.rakambda.channelpointsminer.miner.api.pubsub.data.message.CommunityMomentStart;
 import fr.rakambda.channelpointsminer.miner.api.pubsub.data.message.CreateNotification;
@@ -66,6 +67,8 @@ public abstract class PubSubMessageHandlerAdapter implements IPubSubMessageHandl
 	public void onDropClaim(@NotNull Topic topic, @NotNull DropClaim message){}
 	
 	public void onViewCount(@NotNull Topic topic, @NotNull ViewCount message){}
+	
+	public void onBroadcastSettingsUpdate(@NotNull Topic topic, @NotNull BroadcastSettingsUpdate message){}
 	
 	@Override
 	public void handle(@NotNull Topic topic, @NotNull IPubSubMessage message){

--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/miner/Miner.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/miner/Miner.java
@@ -45,6 +45,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import static fr.rakambda.channelpointsminer.miner.api.pubsub.data.request.topic.TopicName.BROADCAST_SETTINGS_UPDATE;
 import static fr.rakambda.channelpointsminer.miner.api.pubsub.data.request.topic.TopicName.COMMUNITY_MOMENTS_CHANNEL_V1;
 import static fr.rakambda.channelpointsminer.miner.api.pubsub.data.request.topic.TopicName.COMMUNITY_POINTS_USER_V1;
 import static fr.rakambda.channelpointsminer.miner.api.pubsub.data.request.topic.TopicName.ONSITE_NOTIFICATIONS;
@@ -221,6 +222,7 @@ public class Miner implements AutoCloseable, IMiner, ITwitchPubSubMessageListene
 			}
 			
 			listenTopic(VIDEO_PLAYBACK_BY_ID, streamer.getId());
+			listenTopic(BROADCAST_SETTINGS_UPDATE, streamer.getId());
 			
 			if(streamer.getSettings().isMakePredictions()){
 				listenTopic(PREDICTIONS_USER_V1, getTwitchLogin().fetchUserId(gqlApi));
@@ -262,6 +264,7 @@ public class Miner implements AutoCloseable, IMiner, ITwitchPubSubMessageListene
 			}
 			log.info("Removing streamer from the mining list");
 			removeTopic(VIDEO_PLAYBACK_BY_ID, streamer.getId());
+			removeTopic(BROADCAST_SETTINGS_UPDATE, streamer.getId());
 			removeTopic(PREDICTIONS_CHANNEL_V1, streamer.getId());
 			removeTopic(COMMUNITY_MOMENTS_CHANNEL_V1, streamer.getId());
 			removeTopic(RAID, streamer.getId());

--- a/miner/src/test/java/fr/rakambda/channelpointsminer/miner/api/pubsub/TwitchPubSubWebSocketClientMessageTest.java
+++ b/miner/src/test/java/fr/rakambda/channelpointsminer/miner/api/pubsub/TwitchPubSubWebSocketClientMessageTest.java
@@ -2,6 +2,7 @@ package fr.rakambda.channelpointsminer.miner.api.ws;
 
 import fr.rakambda.channelpointsminer.miner.api.pubsub.ITwitchPubSubWebSocketListener;
 import fr.rakambda.channelpointsminer.miner.api.pubsub.TwitchPubSubWebSocketClient;
+import fr.rakambda.channelpointsminer.miner.api.pubsub.data.message.BroadcastSettingsUpdate;
 import fr.rakambda.channelpointsminer.miner.api.pubsub.data.message.ClaimAvailable;
 import fr.rakambda.channelpointsminer.miner.api.pubsub.data.message.CommunityMomentStart;
 import fr.rakambda.channelpointsminer.miner.api.pubsub.data.message.CreateNotification;
@@ -47,6 +48,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.time.ZonedDateTime;
+import static fr.rakambda.channelpointsminer.miner.api.pubsub.data.request.topic.TopicName.BROADCAST_SETTINGS_UPDATE;
 import static fr.rakambda.channelpointsminer.miner.api.pubsub.data.request.topic.TopicName.COMMUNITY_MOMENTS_CHANNEL_V1;
 import static fr.rakambda.channelpointsminer.miner.api.pubsub.data.request.topic.TopicName.COMMUNITY_POINTS_USER_V1;
 import static fr.rakambda.channelpointsminer.miner.api.pubsub.data.request.topic.TopicName.ONSITE_NOTIFICATIONS;
@@ -374,6 +376,24 @@ class TwitchPubSubWebSocketClientMessageTest{
 								.build())
 						.message(ViewCount.builder()
 								.viewers(50L)
+								.build())
+						.build())
+				.build();
+		verify(listener, timeout(MESSAGE_TIMEOUT)).onWebSocketMessage(expected);
+	}
+	
+	@Test
+	void onBroadcastSettingsUpdate(WebsocketMockServer server){
+		server.send(TestUtils.getAllResourceContent("api/ws/broadcastSettingsUpdate.json"));
+		
+		var expected = MessageResponse.builder()
+				.data(MessageData.builder()
+						.topic(Topic.builder()
+								.name(BROADCAST_SETTINGS_UPDATE)
+								.target("987654321")
+								.build())
+						.message(BroadcastSettingsUpdate.builder()
+								.channelId("987654321")
 								.build())
 						.build())
 				.build();

--- a/miner/src/test/java/fr/rakambda/channelpointsminer/miner/miner/MinerTest.java
+++ b/miner/src/test/java/fr/rakambda/channelpointsminer/miner/miner/MinerTest.java
@@ -45,6 +45,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
+import static fr.rakambda.channelpointsminer.miner.api.pubsub.data.request.topic.TopicName.BROADCAST_SETTINGS_UPDATE;
 import static fr.rakambda.channelpointsminer.miner.api.pubsub.data.request.topic.TopicName.COMMUNITY_MOMENTS_CHANNEL_V1;
 import static fr.rakambda.channelpointsminer.miner.api.pubsub.data.request.topic.TopicName.COMMUNITY_POINTS_USER_V1;
 import static fr.rakambda.channelpointsminer.miner.api.pubsub.data.request.topic.TopicName.PREDICTIONS_CHANNEL_V1;
@@ -414,6 +415,7 @@ class MinerTest{
 			verify(updateStreamInfo).run(streamer);
 			verify(hermesWebSocketPool).listenPubSubTopic(Topic.builder().name(PREDICTIONS_USER_V1).target(USER_ID).build());
 			verify(hermesWebSocketPool).listenPubSubTopic(Topic.builder().name(VIDEO_PLAYBACK_BY_ID).target(STREAMER_ID).build());
+			verify(hermesWebSocketPool).listenPubSubTopic(Topic.builder().name(BROADCAST_SETTINGS_UPDATE).target(STREAMER_ID).build());
 			verify(hermesWebSocketPool).listenPubSubTopic(Topic.builder().name(USER_DROP_EVENTS).target(USER_ID).build());
 			verify(hermesWebSocketPool).listenPubSubTopic(Topic.builder().name(PREDICTIONS_CHANNEL_V1).target(STREAMER_ID).build());
 			verify(eventManager).onEvent(new StreamerAddedEvent(streamer, NOW));
@@ -452,6 +454,7 @@ class MinerTest{
 			
 			verify(updateStreamInfo).run(streamer);
 			verify(hermesWebSocketPool).listenPubSubTopic(Topic.builder().name(VIDEO_PLAYBACK_BY_ID).target(STREAMER_ID).build());
+			verify(hermesWebSocketPool).listenPubSubTopic(Topic.builder().name(BROADCAST_SETTINGS_UPDATE).target(STREAMER_ID).build());
 			verify(hermesWebSocketPool).listenPubSubTopic(Topic.builder().name(COMMUNITY_MOMENTS_CHANNEL_V1).target(STREAMER_ID).build());
 			verify(eventManager).onEvent(new StreamerAddedEvent(streamer, NOW));
 		}
@@ -489,6 +492,7 @@ class MinerTest{
 			
 			verify(updateStreamInfo).run(streamer);
 			verify(hermesWebSocketPool).listenPubSubTopic(Topic.builder().name(VIDEO_PLAYBACK_BY_ID).target(STREAMER_ID).build());
+			verify(hermesWebSocketPool).listenPubSubTopic(Topic.builder().name(BROADCAST_SETTINGS_UPDATE).target(STREAMER_ID).build());
 			verify(hermesWebSocketPool).listenPubSubTopic(Topic.builder().name(RAID).target(STREAMER_ID).build());
 			verify(eventManager).onEvent(new StreamerAddedEvent(streamer, NOW));
 		}
@@ -527,6 +531,7 @@ class MinerTest{
 			
 			verify(updateStreamInfo).run(streamer);
 			verify(hermesWebSocketPool).listenPubSubTopic(Topic.builder().name(VIDEO_PLAYBACK_BY_ID).target(STREAMER_ID).build());
+			verify(hermesWebSocketPool).listenPubSubTopic(Topic.builder().name(BROADCAST_SETTINGS_UPDATE).target(STREAMER_ID).build());
 			verify(eventManager).onEvent(new StreamerAddedEvent(streamer, NOW));
 			verify(twitchChatClient, never()).join(any());
 		}
@@ -566,6 +571,7 @@ class MinerTest{
 			
 			verify(updateStreamInfo).run(streamer);
 			verify(hermesWebSocketPool).listenPubSubTopic(Topic.builder().name(VIDEO_PLAYBACK_BY_ID).target(STREAMER_ID).build());
+			verify(hermesWebSocketPool).listenPubSubTopic(Topic.builder().name(BROADCAST_SETTINGS_UPDATE).target(STREAMER_ID).build());
 			verify(eventManager).onEvent(new StreamerAddedEvent(streamer, NOW));
 			verify(twitchChatClient).join(STREAMER_USERNAME);
 		}
@@ -602,6 +608,7 @@ class MinerTest{
 			
 			verify(updateStreamInfo).run(streamer);
 			verify(hermesWebSocketPool).listenPubSubTopic(Topic.builder().name(VIDEO_PLAYBACK_BY_ID).target(STREAMER_ID).build());
+			verify(hermesWebSocketPool).listenPubSubTopic(Topic.builder().name(BROADCAST_SETTINGS_UPDATE).target(STREAMER_ID).build());
 			verify(eventManager).onEvent(new StreamerAddedEvent(streamer, NOW));
 		}
 	}
@@ -686,6 +693,7 @@ class MinerTest{
 			tested.removeStreamer(streamer);
 			
 			verify(hermesWebSocketPool).removePubSubTopic(Topic.builder().name(VIDEO_PLAYBACK_BY_ID).target(STREAMER_ID).build());
+			verify(hermesWebSocketPool).removePubSubTopic(Topic.builder().name(BROADCAST_SETTINGS_UPDATE).target(STREAMER_ID).build());
 			verify(hermesWebSocketPool).removePubSubTopic(Topic.builder().name(PREDICTIONS_CHANNEL_V1).target(STREAMER_ID).build());
 			verify(hermesWebSocketPool).removePubSubTopic(Topic.builder().name(COMMUNITY_MOMENTS_CHANNEL_V1).target(STREAMER_ID).build());
 			verify(hermesWebSocketPool).removePubSubTopic(Topic.builder().name(RAID).target(STREAMER_ID).build());
@@ -764,6 +772,7 @@ class MinerTest{
 			assertDoesNotThrow(() -> tested.updateStreamer(streamer));
 			
 			verify(hermesWebSocketPool).listenPubSubTopic(Topic.builder().name(VIDEO_PLAYBACK_BY_ID).target(STREAMER_ID).build());
+			verify(hermesWebSocketPool).listenPubSubTopic(Topic.builder().name(BROADCAST_SETTINGS_UPDATE).target(STREAMER_ID).build());
 			verify(hermesWebSocketPool).listenPubSubTopic(Topic.builder().name(USER_DROP_EVENTS).target(USER_ID).build());
 			verify(hermesWebSocketPool).listenPubSubTopic(Topic.builder().name(PREDICTIONS_USER_V1).target(USER_ID).build());
 			verify(hermesWebSocketPool).listenPubSubTopic(Topic.builder().name(PREDICTIONS_CHANNEL_V1).target(STREAMER_ID).build());

--- a/miner/src/test/resources/api/ws/broadcastSettingsUpdate.json
+++ b/miner/src/test/resources/api/ws/broadcastSettingsUpdate.json
@@ -2,6 +2,6 @@
   "type" : "MESSAGE",
   "data" : {
     "topic" : "broadcast-settings-update.987654321",
-    "message" : "{\\\"channel_id\\\":\\\"987654321\\\",\\\"type\\\":\\\"broadcast_settings_update\\\",\\\"channel\\\":\\\"channel\\\",\\\"old_status\\\":\\\"\\\",\\\"status\\\":\\\"\\\",\\\"old_game\\\":\\\"\\\",\\\"game\\\":\\\"\\\",\\\"old_game_id\\\":0,\\\"game_id\\\":0}"
+    "message" : "{\"channel_id\":\"987654321\",\"type\":\"broadcast_settings_update\",\"channel\":\"channel\",\"old_status\":\"\",\"status\":\"\",\"old_game\":\"\",\"game\":\"\",\"old_game_id\":0,\"game_id\":0}"
   }
 }

--- a/miner/src/test/resources/api/ws/broadcastSettingsUpdate.json
+++ b/miner/src/test/resources/api/ws/broadcastSettingsUpdate.json
@@ -1,0 +1,7 @@
+{
+  "type" : "MESSAGE",
+  "data" : {
+    "topic" : "broadcast-settings-update.987654321",
+    "message" : "{\\\"channel_id\\\":\\\"987654321\\\",\\\"type\\\":\\\"broadcast_settings_update\\\",\\\"channel\\\":\\\"channel\\\",\\\"old_status\\\":\\\"\\\",\\\"status\\\":\\\"\\\",\\\"old_game\\\":\\\"\\\",\\\"game\\\":\\\"\\\",\\\"old_game_id\\\":0,\\\"game_id\\\":0}"
+  }
+}


### PR DESCRIPTION
## Pull Request Etiquette

### Checklist

- [x] Tests have been added in relevant areas
- [x] Corresponding changes made to the documentation (README.adoc) <!-- (if irrelevant check the box too) -->

### Type of change
New Feature

## Description
This event is sent when stream start/stops. However it doesn't send enough info to know if the stream started or ended so we'll have to rely on our internal state which may be unreliable sometimes.
